### PR TITLE
Document MRT file format change on 2023-04-03

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,12 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.17.2
+    rev: v0.22.1
     hooks:
     - id: markdownlint-cli2

--- a/ris-mrt-files.md
+++ b/ris-mrt-files.md
@@ -85,6 +85,11 @@ Update files between ~12:25 and ~13:55 UTC are significantly larger than expecte
 
 After de-peering `2a00:1e68:112::1` (`AS 42861`) on `rrc00`, some routes from
 this peer were stuck in our processing pipeline. We did not detect this early
+
+#### 2023-04-03: MRT file format/size change
+
+As per [this email](https://www.mail-archive.com/ris-users@ripe.net/msg00035.html)
+the MRT file format was fixed, resulting in much smaller output files
 due to missing consistency checks.
 
 These routes were present in the table dumps (bview files) until 9 May 2025

--- a/ris-mrt-files.md
+++ b/ris-mrt-files.md
@@ -93,5 +93,5 @@ These routes were present in the table dumps (bview files) until 9 May 2025
 #### 2023-04-03: MRT file format/size change
 
 As per [this email](https://www.mail-archive.com/ris-users@ripe.net/msg00035.html)
-the internal structure of the MRT bview files changed after we migrated to a 
+the internal structure of the MRT bview files changed after we migrated to a
 different software pipeline. This resulted in much smaller output files without changes to the data.

--- a/ris-mrt-files.md
+++ b/ris-mrt-files.md
@@ -85,12 +85,13 @@ Update files between ~12:25 and ~13:55 UTC are significantly larger than expecte
 
 After de-peering `2a00:1e68:112::1` (`AS 42861`) on `rrc00`, some routes from
 this peer were stuck in our processing pipeline. We did not detect this early
-
-#### 2023-04-03: MRT file format/size change
-
-As per [this email](https://www.mail-archive.com/ris-users@ripe.net/msg00035.html)
-the MRT file format was fixed, resulting in much smaller output files
 due to missing consistency checks.
 
 These routes were present in the table dumps (bview files) until 9 May 2025
 (first removed in [bview.20250509.1600.gz](https://data.ris.ripe.net/rrc00/2025.05/bview.20250509.1600.gz)).
+
+#### 2023-04-03: MRT file format/size change
+
+As per [this email](https://www.mail-archive.com/ris-users@ripe.net/msg00035.html)
+the internal structure of the MRT bview files changed after we migrated to a 
+different software pipeline. This resulted in much smaller output files without changes to the data.


### PR DESCRIPTION
Added information about MRT file format changes and their impact on output file size.